### PR TITLE
Bump minimum nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
-  - '4'
-  - '5'
+  - '8'
+  - '9'
+  - 'node'
 before_install:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 8.9.3"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Version should match core. Also updates travis versions.

See: https://core.trac.wordpress.org/ticket/35105