### PR TITLE
chore: update Grunt to version `1.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "nyc": "^11.4.1"
   },
   "dependencies": {
-    "grunt": ">=0.4.5",
+    "grunt": "^1.0.2",
     "inquirer": "^5.1.0",
     "request": "^2.83.0",
     "underscore": "~1.8.3",


### PR DESCRIPTION
See [#WP42308](https://core.trac.wordpress.org/ticket/42308)