### PR TITLE
chore: update underscore to version `1.9.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt": "^1.0.2",
     "inquirer": "^5.1.0",
     "request": "^2.83.0",
-    "underscore": "~1.8.3",
+    "underscore": "~1.9.0",
     "underscore.string": "~3.3.4",
     "xmlrpc": "^1.3.1"
   },


### PR DESCRIPTION
Changelog: https://github.com/jashkenas/underscore/compare/1.8.3...1.9.0

There is no changelog summary available, only the above which is pretty much unreadable due to the 400+ commits as it is the first release in ~3 years /shrug 