### PR TITLE
Travis CI: Use Node.js 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - '8'
-  - '9'
+  - '10'
   - 'node'
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
The Node.js 9.x "latest" branch has been superseded by the 10.x branch and testing against Node.js 9.x is no longer required.