### PR TITLE
Re-add node 9 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - '8'
+  - '9'
   - '10'
   - 'node'
 before_install:


### PR DESCRIPTION
Node 9 isn't EOL until the end of June 2018. Tests should run on it until it is no longer supported.

Followup to #63