### PR TITLE
Update Grunt to `1.0.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"jest": "^24.5.0"
 	},
 	"dependencies": {
-		"grunt": "^1.0.2",
+		"grunt": "^1.0.3",
 		"inquirer": "^5.1.0",
 		"request": "^2.83.0",
 		"xmlrpc": "^1.3.1"


### PR DESCRIPTION
Ref https://github.com/WordPress/grunt-patch-wordpress/issues/65#issuecomment-393030460