### PR TITLE
Convert test suites to use jest instead of nyc, mocha, and chai

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,6 +1,9 @@
 var grunt = require( 'grunt' ),
 	_ = require( 'underscore' );
 
+_.str = _.str = require( 'underscore.string' );
+_.mixin( _.str.exports() );
+
 module.exports = {
 	isAb: function( diff ) {
 		var ab = false;

--- a/package.json
+++ b/package.json
@@ -21,18 +21,19 @@
     "node": ">= 8.9.3"
   },
   "scripts": {
-    "test": "mocha",
-    "test:coverage": "nyc mocha",
-    "test:watch": "mocha -w",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch",
     "lint": "eslint . --ignore-path coverage",
     "lint:fix": "eslint . --fix"
   },
+  "jest": {
+    "testMatch": [ "**/test/**/*.js" ]
+  },
   "devDependencies": {
-    "chai": "^4.1.2",
     "eslint": "^4.17.0",
     "eslint-config-wordpress": "^2.0.0",
-    "mocha": "^5.0.0",
-    "nyc": "^11.4.1"
+    "jest": "^24.5.0"
   },
   "dependencies": {
     "grunt": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "lint:fix": "eslint . --fix"
   },
   "jest": {
-    "testMatch": [ "**/test/**/*.js" ]
+    "testMatch": [
+      "**/test/**/*.js"
+    ]
   },
   "devDependencies": {
     "eslint": "^4.17.0",

--- a/test/patch_wordpress_test.js
+++ b/test/patch_wordpress_test.js
@@ -3,21 +3,20 @@
 var grunt = require( 'grunt' ),
 	patch = require( '../lib/patch.js' ),
 	url = require( 'url' ),
-	expect = require( 'chai' ).expect,
 	trac = require( '../lib/trac.js' ),
 	mapOldToNewFilePath = require( '../lib/map_old_to_new_file_path.js' );
 
 describe( 'grunt_patch_wordpress', function() {
 	describe( 'sanity checks', function() {
 		it( 'a is a', function( done ) {
-			expect( 'a' ).to.equal( 'a' );
+			expect( 'a' ).toEqual( 'a' );
 			done();
 		});
 
 	});
 
 	it( 'convertToRaw converts urls', function( done ) {
-		expect( trac.convertToRaw ( url.parse( 'https://core.trac.wordpress.org/attachment/ticket/26700/26700.diff'  ) ) ).to.equal( 'https://core.trac.wordpress.org/raw-attachment/ticket/26700/26700.diff' );
+		expect( trac.convertToRaw ( url.parse( 'https://core.trac.wordpress.org/attachment/ticket/26700/26700.diff'  ) ) ).toEqual( 'https://core.trac.wordpress.org/raw-attachment/ticket/26700/26700.diff' );
 		done();
 	});
 
@@ -27,7 +26,7 @@ describe( 'grunt_patch_wordpress', function() {
 
 		it ( '26602.2.diff is 0', function( done ) {
 			var file = grunt.file.read( 'test/fixtures/26602.2.diff' );
-			expect( patch.isAb( file ) ).to.be.false;
+			expect( patch.isAb( file ) ).toBe( false );
 			done();
 		});
 	});
@@ -39,7 +38,7 @@ describe( 'grunt_patch_wordpress', function() {
 		};
 
 		describe( 'old to new', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_1.diff', './test/tmp/patch_wordpress_1_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_1_copy.diff', fileMappings );
 			});
@@ -48,16 +47,16 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_1.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_1_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_1_copy.diff' );
 			});
 		});
 
 		describe( 'new stay unchanged', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_2.diff', './test/tmp/patch_wordpress_2_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_2_copy.diff', fileMappings );
 			});
@@ -66,16 +65,16 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_2.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_2_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_2_copy.diff' );
 			});
 		});
 
 		describe( 'unknown stay unchanged', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_3.diff', './test/tmp/patch_wordpress_3_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_3_copy.diff', fileMappings );
 			});
@@ -84,16 +83,16 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_3.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_3_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_3_copy.diff' );
 			});
 		});
 
 		describe( 'new stay unchanged, old to new', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_4.diff', './test/tmp/patch_wordpress_4_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_4_copy.diff', fileMappings );
 			});
@@ -103,16 +102,16 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_4.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_4_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_4_copy.diff' );
 			});
 		});
 
 		describe( 'new and unknown stay unchanged', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_5.diff', './test/tmp/patch_wordpress_5_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_5_copy.diff', fileMappings );
 			});
@@ -122,16 +121,16 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_5.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_5_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_5_copy.diff' );
 			});
 		});
 
 		describe( 'new and unknown stay unchanged, old to new', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_6.diff', './test/tmp/patch_wordpress_6_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_6_copy.diff', fileMappings );
 			});
@@ -140,17 +139,17 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_6.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_6_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_6_copy.diff' );
 			});
 		});
 
 		// There is no src folder in core.
 		describe( 'non-src old to new', function() {
-			before( function() {
+			beforeAll( function() {
 				grunt.file.copy( './test/fixtures/patch_wordpress_7.diff', './test/tmp/patch_wordpress_7_copy.diff' );
 				mapOldToNewFilePath( './test/tmp/patch_wordpress_7_copy.diff', fileMappings );
 			});
@@ -159,10 +158,10 @@ describe( 'grunt_patch_wordpress', function() {
 				var expected = grunt.file.read( './test/expected/patch_wordpress_7.diff' );
 				var actual = grunt.file.read( './test/tmp/patch_wordpress_7_copy.diff' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			});
 
-			after( function() {
+			afterAll( function() {
 				grunt.file.delete( './test/tmp/patch_wordpress_7_copy.diff' );
 			});
 		});

--- a/test/patch_wordpress_test.js
+++ b/test/patch_wordpress_test.js
@@ -8,26 +8,23 @@ var grunt = require( 'grunt' ),
 
 describe( 'grunt_patch_wordpress', function() {
 	describe( 'sanity checks', function() {
-		it( 'a is a', function( done ) {
+		it( 'a is a', function() {
 			expect( 'a' ).toEqual( 'a' );
-			done();
 		});
 
 	});
 
-	it( 'convertToRaw converts urls', function( done ) {
+	it( 'convertToRaw converts urls', function() {
 		expect( trac.convertToRaw ( url.parse( 'https://core.trac.wordpress.org/attachment/ticket/26700/26700.diff'  ) ) ).toEqual( 'https://core.trac.wordpress.org/raw-attachment/ticket/26700/26700.diff' );
-		done();
 	});
 
 	describe( 'Level Calculator', function() {
 
 		// @TODO: Find alot of patches to use here
 
-		it ( '26602.2.diff is 0', function( done ) {
+		it ( '26602.2.diff is 0', function() {
 			var file = grunt.file.read( 'test/fixtures/26602.2.diff' );
 			expect( patch.isAb( file ) ).toBe( false );
-			done();
 		});
 	});
 

--- a/test/patches.js
+++ b/test/patches.js
@@ -1,5 +1,4 @@
 var grunt = require( 'grunt' ),
-	expect = require( 'chai' ).expect,
 	patch = require( '../lib/patch.js' ),
 	coreGit = grunt.file.read ( 'test/fixtures/core.git.diff' ),
 	coreSvn = grunt.file.read ( 'test/fixtures/core.svn.diff' ),
@@ -19,69 +18,69 @@ var grunt = require( 'grunt' ),
 describe( 'Patch helpers', function() {
 
 	it( 'git a/b diffs should not automatticaly trigger moving to src', function( done ) {
-		expect( patch.moveToSrc( abyes ) ).to.not.be.true;
+		expect( patch.moveToSrc( abyes ) ).not.toBe( true );
 
 		done();
 	});
 
 	it( 'tests diffs should always be applied in the root of the checkout', function( done ) {
 
-		expect( patch.moveToSrc( testsGit ) ).to.not.be.true;
-		expect( patch.moveToSrc( testsSvn ) ).to.not.be.true;
+		expect( patch.moveToSrc( testsGit ) ).not.toBe( true );
+		expect( patch.moveToSrc( testsSvn ) ).not.toBe( true );
 
 		done();
 	});
 
 	it( 'dev.git diffs should always be applied in the root of the checkout', function( done ) {
 
-		expect( patch.moveToSrc( developGit ) ).to.not.be.true;
-		expect( patch.moveToSrc( developIndexGit ) ).to.not.be.true;
+		expect( patch.moveToSrc( developGit ) ).not.toBe( true );
+		expect( patch.moveToSrc( developIndexGit ) ).not.toBe( true );
 
 		done();
 	});
 
 	it( 'dev.svn diffs should always be applied in the root of the checkout', function( done ) {
 
-		expect( patch.moveToSrc( developSvn ) ).to.not.be.true;
-		expect( patch.moveToSrc( developIndexSvn ) ).to.not.be.true;
+		expect( patch.moveToSrc( developSvn ) ).not.toBe( true );
+		expect( patch.moveToSrc( developIndexSvn ) ).not.toBe( true );
 
 		done();
 	});
 
 	it( 'core.git.wordpress.org diffs should always be applied in the svn folder', function( done ) {
 
-		expect( patch.moveToSrc( coreGit ) ).to.be.true;
+		expect( patch.moveToSrc( coreGit ) ).toBe( true );
 
 		done();
 	});
 
 	it( 'core.svn.wordpress.org diffs should always be applied in the svn folder', function( done ) {
 
-		expect( patch.moveToSrc( coreSvn ) ).to.be.true;
+		expect( patch.moveToSrc( coreSvn ) ).toBe( true );
 
 		done();
 	});
 
 	it( 'core.svn.wordpress.org diffs from trunk should always be applied in the src folder', function( done ) {
 
-		expect( patch.moveToSrc( coreTrunkSvn ) ).to.be.true;
-		expect( patch.isAb( coreTrunkSvn ) ).to.be.true;
+		expect( patch.moveToSrc( coreTrunkSvn ) ).toBe( true );
+		expect( patch.isAb( coreTrunkSvn ) ).toBe( true );
 
 		done();
 	});
 
 	it( 'index.php should always be applied in the src folder', function( done ) {
 
-		expect( patch.moveToSrc( coreIndexSvn ) ).to.be.true;
-		expect( patch.moveToSrc( coreIndexGit ) ).to.be.true;
+		expect( patch.moveToSrc( coreIndexSvn ) ).toBe( true );
+		expect( patch.moveToSrc( coreIndexGit ) ).toBe( true );
 
 		done();
 
 	});
 
 	it( 'wp-config-sample.php should always be applied in the root folder', function( done ) {
-		expect( patch.moveToSrc( developSampleSvn ) ).to.not.be.true;
-		expect( patch.moveToSrc( developSampleGit ) ).to.not.be.true;
+		expect( patch.moveToSrc( developSampleSvn ) ).not.toBe( true );
+		expect( patch.moveToSrc( developSampleGit ) ).not.toBe( true );
 
 		done();
 
@@ -89,25 +88,25 @@ describe( 'Patch helpers', function() {
 
 	it ( 'isAb should return true on patches with a/ b/ style', function( done ) {
 
-		expect( patch.isAb( abyes ) ).to.be.true;
+		expect( patch.isAb( abyes ) ).toBe( true );
 
 		done();
 	});
 
 	it ( 'isAb should return false on patches without a/ b/ style', function( done ) {
 
-		expect( patch.isAb( developSampleGit ) ).to.not.be.true;
-		expect( patch.isAb( developSampleSvn ) ).to.not.be.true;
-		expect( patch.isAb( coreIndexGit ) ).to.not.be.true;
-		expect( patch.isAb( coreIndexSvn ) ).to.not.be.true;
-		expect( patch.isAb( coreGit ) ).to.not.be.true;
-		expect( patch.isAb( coreSvn ) ).to.not.be.true;
-		expect( patch.isAb( developGit ) ).to.not.be.true;
-		expect( patch.isAb( developSvn ) ).to.not.be.true;
-		expect( patch.isAb( developIndexGit ) ).to.not.be.true;
-		expect( patch.isAb( developIndexSvn ) ).to.not.be.true;
-		expect( patch.isAb( testsGit ) ).to.not.be.true;
-		expect( patch.isAb( testsSvn ) ).to.not.be.true;
+		expect( patch.isAb( developSampleGit ) ).not.toBe( true );
+		expect( patch.isAb( developSampleSvn ) ).not.toBe( true );
+		expect( patch.isAb( coreIndexGit ) ).not.toBe( true );
+		expect( patch.isAb( coreIndexSvn ) ).not.toBe( true );
+		expect( patch.isAb( coreGit ) ).not.toBe( true );
+		expect( patch.isAb( coreSvn ) ).not.toBe( true );
+		expect( patch.isAb( developGit ) ).not.toBe( true );
+		expect( patch.isAb( developSvn ) ).not.toBe( true );
+		expect( patch.isAb( developIndexGit ) ).not.toBe( true );
+		expect( patch.isAb( developIndexSvn ) ).not.toBe( true );
+		expect( patch.isAb( testsGit ) ).not.toBe( true );
+		expect( patch.isAb( testsSvn ) ).not.toBe( true );
 
 		done();
 	});

--- a/test/patches.js
+++ b/test/patches.js
@@ -17,83 +17,60 @@ var grunt = require( 'grunt' ),
 
 describe( 'Patch helpers', function() {
 
-	it( 'git a/b diffs should not automatticaly trigger moving to src', function( done ) {
+	it( 'git a/b diffs should not automatticaly trigger moving to src', function() {
 		expect( patch.moveToSrc( abyes ) ).not.toBe( true );
-
-		done();
 	});
 
-	it( 'tests diffs should always be applied in the root of the checkout', function( done ) {
+	it( 'tests diffs should always be applied in the root of the checkout', function() {
 
 		expect( patch.moveToSrc( testsGit ) ).not.toBe( true );
 		expect( patch.moveToSrc( testsSvn ) ).not.toBe( true );
-
-		done();
 	});
 
-	it( 'dev.git diffs should always be applied in the root of the checkout', function( done ) {
+	it( 'dev.git diffs should always be applied in the root of the checkout', function() {
 
 		expect( patch.moveToSrc( developGit ) ).not.toBe( true );
 		expect( patch.moveToSrc( developIndexGit ) ).not.toBe( true );
-
-		done();
 	});
 
-	it( 'dev.svn diffs should always be applied in the root of the checkout', function( done ) {
+	it( 'dev.svn diffs should always be applied in the root of the checkout', function() {
 
 		expect( patch.moveToSrc( developSvn ) ).not.toBe( true );
 		expect( patch.moveToSrc( developIndexSvn ) ).not.toBe( true );
-
-		done();
 	});
 
-	it( 'core.git.wordpress.org diffs should always be applied in the svn folder', function( done ) {
+	it( 'core.git.wordpress.org diffs should always be applied in the svn folder', function() {
 
 		expect( patch.moveToSrc( coreGit ) ).toBe( true );
-
-		done();
 	});
 
-	it( 'core.svn.wordpress.org diffs should always be applied in the svn folder', function( done ) {
+	it( 'core.svn.wordpress.org diffs should always be applied in the svn folder', function() {
 
 		expect( patch.moveToSrc( coreSvn ) ).toBe( true );
-
-		done();
 	});
 
-	it( 'core.svn.wordpress.org diffs from trunk should always be applied in the src folder', function( done ) {
+	it( 'core.svn.wordpress.org diffs from trunk should always be applied in the src folder', function() {
 
 		expect( patch.moveToSrc( coreTrunkSvn ) ).toBe( true );
 		expect( patch.isAb( coreTrunkSvn ) ).toBe( true );
-
-		done();
 	});
 
-	it( 'index.php should always be applied in the src folder', function( done ) {
-
+	it( 'index.php should always be applied in the src folder', function() {
 		expect( patch.moveToSrc( coreIndexSvn ) ).toBe( true );
 		expect( patch.moveToSrc( coreIndexGit ) ).toBe( true );
-
-		done();
-
 	});
 
-	it( 'wp-config-sample.php should always be applied in the root folder', function( done ) {
+	it( 'wp-config-sample.php should always be applied in the root folder', function() {
 		expect( patch.moveToSrc( developSampleSvn ) ).not.toBe( true );
 		expect( patch.moveToSrc( developSampleGit ) ).not.toBe( true );
-
-		done();
-
 	});
 
-	it ( 'isAb should return true on patches with a/ b/ style', function( done ) {
+	it ( 'isAb should return true on patches with a/ b/ style', function() {
 
 		expect( patch.isAb( abyes ) ).toBe( true );
-
-		done();
 	});
 
-	it ( 'isAb should return false on patches without a/ b/ style', function( done ) {
+	it ( 'isAb should return false on patches without a/ b/ style', function() {
 
 		expect( patch.isAb( developSampleGit ) ).not.toBe( true );
 		expect( patch.isAb( developSampleSvn ) ).not.toBe( true );
@@ -107,8 +84,6 @@ describe( 'Patch helpers', function() {
 		expect( patch.isAb( developIndexSvn ) ).not.toBe( true );
 		expect( patch.isAb( testsGit ) ).not.toBe( true );
 		expect( patch.isAb( testsSvn ) ).not.toBe( true );
-
-		done();
 	});
 
 });

--- a/test/regex.js
+++ b/test/regex.js
@@ -1,5 +1,4 @@
 var grunt = require( 'grunt' ),
-	expect = require( 'chai' ).expect,
 	regex = require( '../lib/regex.js' ),
 	html23988 = grunt.file.read ( 'test/fixtures/23988.html' ),
 	html23989 = grunt.file.read ( 'test/fixtures/23989.html' ),
@@ -11,9 +10,9 @@ describe( 'regular expressions', function() {
 			longMatches = regex.longMatches( html23988 ),
 			possiblePatches = regex.possiblePatches( longMatches );
 
-		expect( matches ).to.have.length( 2 );
-		expect( longMatches ).to.have.length( 4 );
-		expect( possiblePatches ).to.have.length( 2 );
+		expect( matches.length ).toBe( 2 );
+		expect( longMatches.length ).toBe( 4 );
+		expect( possiblePatches.length ).toBe( 2 );
 
 		done();
 	});
@@ -21,7 +20,7 @@ describe( 'regular expressions', function() {
 	it( 'one patch on a ticket', function( done ) {
 		var matches = regex.patchAttachments( html23994 );
 
-		expect( matches ).to.have.length( 1 );
+		expect( matches.length ).toBe( 1 );
 		done();
 	});
 
@@ -29,21 +28,21 @@ describe( 'regular expressions', function() {
 		var matches = regex.patchAttachments( html23994 );
 		url = 'core.trac.wordpress.org' + regex.urlsFromAttachmentList(   matches[0])[1];
 
-		expect( url ).to.be.equal( 'core.trac.wordpress.org/attachment/ticket/23994/23994.diff' );
+		expect( url ).toBe( 'core.trac.wordpress.org/attachment/ticket/23994/23994.diff' );
 		done();
 	});
 
 	it( 'no patches on a ticket', function( done ) {
 		var matches = regex.patchAttachments( html23989 );
 
-		expect( matches ).to.be.null;
+		expect( matches ).toBeNull();
 		done();
 	});
 
 	it( 'filenames should be cleaned', function( done ) {
 		var filename = '?       one.diff';
 
-		expect( regex.localFileClean( filename ) ).to.equal( 'one.diff' );
+		expect( regex.localFileClean( filename ) ).toEqual( 'one.diff' );
 		done();
 	});
 });

--- a/test/regex.js
+++ b/test/regex.js
@@ -5,7 +5,7 @@ var grunt = require( 'grunt' ),
 	html23994 = grunt.file.read ( 'test/fixtures/23994.html' );
 
 describe( 'regular expressions', function() {
-	it( 'multiple patches on a ticket with non patches as well', function( done ) {
+	it( 'multiple patches on a ticket with non patches as well', function() {
 		var matches = regex.patchAttachments( html23988 ),
 			longMatches = regex.longMatches( html23988 ),
 			possiblePatches = regex.possiblePatches( longMatches );
@@ -13,36 +13,30 @@ describe( 'regular expressions', function() {
 		expect( matches.length ).toBe( 2 );
 		expect( longMatches.length ).toBe( 4 );
 		expect( possiblePatches.length ).toBe( 2 );
-
-		done();
 	});
 
-	it( 'one patch on a ticket', function( done ) {
+	it( 'one patch on a ticket', function() {
 		var matches = regex.patchAttachments( html23994 );
 
 		expect( matches.length ).toBe( 1 );
-		done();
 	});
 
-	it( 'url from a list of attachments', function( done ) {
+	it( 'url from a list of attachments', function() {
 		var matches = regex.patchAttachments( html23994 );
 		url = 'core.trac.wordpress.org' + regex.urlsFromAttachmentList(   matches[0])[1];
 
 		expect( url ).toBe( 'core.trac.wordpress.org/attachment/ticket/23994/23994.diff' );
-		done();
 	});
 
-	it( 'no patches on a ticket', function( done ) {
+	it( 'no patches on a ticket', function() {
 		var matches = regex.patchAttachments( html23989 );
 
 		expect( matches ).toBeNull();
-		done();
 	});
 
-	it( 'filenames should be cleaned', function( done ) {
+	it( 'filenames should be cleaned', function() {
 		var filename = '?       one.diff';
 
 		expect( regex.localFileClean( filename ) ).toEqual( 'one.diff' );
-		done();
 	});
 });


### PR DESCRIPTION
For #70 

Converts this project to use [Jest](https://jestjs.io) instead of Mocha, Chai, & `nyc`.