### PR TITLE
Allow credentials to be retrieved from the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ After you've made changes to your local WordPress develop repository, you can up
 grunt upload_patch:2907
 ```
 
+You can also store your WordPress.org credentials in environment variables. Please exercise caution when using this option, as it may cause your credentials to be leaked!
+
+```bash
+export WPORG_USERNAME=matt
+export WPORG_PASSWORD=MyPasswordIsVerySecure12345
+grunt uploadPatch:40000
+```
+
 ## Using the file_mappings option
 If you'd like to map old file paths in your patch to new file paths during the patching process, you can pass a file mappings object as an option. Using this option can be helpful when the file paths in the project have been changed since you've created your patch.
 

--- a/tasks/patch_wordpress.js
+++ b/tasks/patch_wordpress.js
@@ -326,13 +326,17 @@ module.exports = function( grunt ) {
 				);
 			} );
 		};
-		inquirer.prompt(
-			[
-				{ type: 'input', name: 'username', message: 'Enter your WordPress.org username' },
-				{ type: 'password', name: 'password', message: 'Enter your WordPress.org password' },
-			] ).then( ( answers ) => {
-			uploadPatchWithCredentials( answers.username, answers.password );
+		if ( process.env.WPORG_USERNAME && process.env.WPORG_PASSWORD ) {
+			uploadPatchWithCredentials( process.env.WPORG_USERNAME, process.env.WPORG_PASSWORD );
+		} else {
+			inquirer.prompt(
+				[
+					{ type: 'input', name: 'username', message: 'Enter your WordPress.org username' },
+					{ type: 'password', name: 'password', message: 'Enter your WordPress.org password' },
+				] ).then( ( answers ) => {
+				uploadPatchWithCredentials( answers.username, answers.password );
+			}
+			);
 		}
-		);
 	} );
 };


### PR DESCRIPTION
So that the `upload_patch` task can be run programatically, it would be helpful if it could retrieve WordPress.org credentials from the environment.

## To Test

In WordPress' `package.json`, set `grunt-patch-wordpress` to `WordPress/grunt-patch-wordpress#add/credentials-from-environment`, then run `npm install`.

Run:

```bash
export WPORG_USERNAME=matt
export WPORG_PASSWORD=MyPasswordIsVerySecure12345
grunt uploadPatch:40000
```
