### PR TITLE
Delete superfluous `contribute.md` file

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -1,3 +1,0 @@
-When filing a bug report, please include the output when the grunt task is run in [debug mode](http://gruntjs.com/using-the-cli#debug-d) with ```--debug``` or ```-d```
-
-Please also include the command you ran and the selections you made (if any)


### PR DESCRIPTION
This file is superfluous as we also have a `CONTRIBUTING.md` file at:
> https://github.com/WordPress/grunt-patch-wordpress/blob/master/CONTRIBUTING.md

GitHub also recommend using `CONTRIBUTING.md` as the file name per the [docs here](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization#supported-file-types)